### PR TITLE
Add patient and doctor management endpoints

### DIFF
--- a/backend/app/Http/Controllers/DoctorController.php
+++ b/backend/app/Http/Controllers/DoctorController.php
@@ -2,15 +2,15 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Patient;
+use App\Models\Doctor;
 use Illuminate\Http\Request;
 
-class PatientController extends Controller
+class DoctorController extends Controller
 {
     public function index()
     {
         return response()
-            ->json(Patient::all())
+            ->json(Doctor::all())
             ->header('Access-Control-Allow-Origin', '*');
     }
 
@@ -21,37 +21,37 @@ class PatientController extends Controller
             'phone' => 'nullable|string|max:255',
         ]);
 
-        $patient = Patient::create($data);
+        $doctor = Doctor::create($data);
 
         return response()
-            ->json($patient, 201)
+            ->json($doctor, 201)
             ->header('Access-Control-Allow-Origin', '*');
     }
 
-    public function show(Patient $patient)
+    public function show(Doctor $doctor)
     {
         return response()
-            ->json($patient)
+            ->json($doctor)
             ->header('Access-Control-Allow-Origin', '*');
     }
 
-    public function update(Request $request, Patient $patient)
+    public function update(Request $request, Doctor $doctor)
     {
         $data = $request->validate([
             'name' => 'sometimes|required|string|max:255',
             'phone' => 'nullable|string|max:255',
         ]);
 
-        $patient->update($data);
+        $doctor->update($data);
 
         return response()
-            ->json($patient)
+            ->json($doctor)
             ->header('Access-Control-Allow-Origin', '*');
     }
 
-    public function destroy(Patient $patient)
+    public function destroy(Doctor $doctor)
     {
-        $patient->delete();
+        $doctor->delete();
 
         return response()
             ->noContent()

--- a/backend/app/Models/Doctor.php
+++ b/backend/app/Models/Doctor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Doctor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'phone',
+    ];
+}

--- a/backend/database/migrations/2025_07_29_000002_create_doctors_table.php
+++ b/backend/database/migrations/2025_07_29_000002_create_doctors_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('doctors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('doctors');
+    }
+};

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:pHRRMkAFOTtFDDJJ5rxIgHYsD/6tVgZH2XBXz+27Gzs="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-
 use App\Http\Controllers\PatientController;
+use App\Http\Controllers\DoctorController;
 
-Route::get('/patients', [PatientController::class, 'index']);
-
+Route::apiResource('patients', PatientController::class);
+Route::apiResource('doctors', DoctorController::class);

--- a/backend/tests/Feature/PatientDoctorTest.php
+++ b/backend/tests/Feature/PatientDoctorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PatientDoctorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_patient_management(): void
+    {
+        $payload = ['name' => 'John Doe', 'phone' => '123456789'];
+
+        $this->postJson('/api/patients', $payload)
+            ->assertStatus(201)
+            ->assertJsonFragment($payload);
+
+        $this->getJson('/api/patients')
+            ->assertStatus(200)
+            ->assertJsonFragment($payload);
+    }
+
+    public function test_doctor_management(): void
+    {
+        $payload = ['name' => 'Dr. Smith', 'phone' => '555-1234'];
+
+        $this->postJson('/api/doctors', $payload)
+            ->assertStatus(201)
+            ->assertJsonFragment($payload);
+
+        $this->getJson('/api/doctors')
+            ->assertStatus(200)
+            ->assertJsonFragment($payload);
+    }
+}


### PR DESCRIPTION
## Summary
- extend patient management with CRUD endpoints
- add doctor resource with model, migration, controller and routes
- cover patient and doctor workflows with feature tests

## Testing
- `composer install`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_688dfabc6a708324bf6a0cded0bcf900